### PR TITLE
PLAT-4008 Fix implicit float-to-int conversion in Kasko::ROUND()

### DIFF
--- a/src/PhpSpreadsheet/Calculation/Kasko.php
+++ b/src/PhpSpreadsheet/Calculation/Kasko.php
@@ -24,7 +24,7 @@ class Kasko
         $num       = Functions::flattenSingleValue($num);
         $precision = Functions::flattenSingleValue($precision);
 
-        return round((float) $num, $precision);
+        return round((float) $num, (int) $precision);
     }
 
     /**


### PR DESCRIPTION
### Description

Cast `$precision` to `(int)` in `Kasko::ROUND()` before passing to PHP's `round()`.

Production is emitting deprecation warnings because `round()` expects an `int` for the precision parameter, but Excel formulas can yield a float. This will become a `TypeError` in a future PHP version.

### Relevant tickets

PLAT-4008

### Checklist
- [ ] I have tested this code on qa
- [ ] I have added necessary audit trail events